### PR TITLE
boot-qemu.sh: Add '-nodefaults' to ppc64le command line

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -154,7 +154,8 @@ function setup_qemu_args() {
                              -device "ipmi-bmc-sim,id=bmc0"
                              -device "isa-ipmi-bt,bmc=bmc0,irq=10"
                              -L "${IMAGES_DIR}/" -bios skiboot.lid
-                             -machine powernv )
+                             -machine powernv
+                             -nodefaults )
             QEMU_RAM=2G
             QEMU=( qemu-system-ppc64 ) ;;
 


### PR DESCRIPTION
An upcoming QEMU change will make it so that the bmc devices are created
automatically. Unfortunately, that breaks our command line with the
following cryptic error:

  qemu-system-ppc64: error creating device tree: node: FDT_ERR_EXISTS

The author of the patch changed it so that the devices are only created
when '-nodefaults' is not set (i.e. using defaults). Add this flag to
our QEMU command line so that this command line continues to work for
all QEMU versions. Tested locally with 3.1.0 (the version in Debian
stable), 4.2.0 (current QEMU stable), and 5.0.0-rc1 (latest QEMU -rc).

Link: https://lore.kernel.org/qemu-devel/20200404071707.GA24708@ubuntu-m2-xlarge-x86/
Link: https://lore.kernel.org/qemu-devel/20200404153655.166834-1-clg@kaod.org/