### PR TITLE
boot-qemu.sh: Hoist '-nodefaults' from ppc64le arguments to main arguments

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -154,8 +154,7 @@ function setup_qemu_args() {
                              -device "ipmi-bmc-sim,id=bmc0"
                              -device "isa-ipmi-bt,bmc=bmc0,irq=10"
                              -L "${IMAGES_DIR}/" -bios skiboot.lid
-                             -machine powernv
-                             -nodefaults )
+                             -machine powernv )
             QEMU_RAM=2G
             QEMU=( qemu-system-ppc64 ) ;;
 
@@ -186,6 +185,7 @@ function invoke_qemu() {
         -initrd "${ROOTFS}" \
         -kernel "${KERNEL}" \
         -m "${QEMU_RAM:=512m}" \
+        -nodefaults \
         -serial mon:stdio
     RET=${?}
     set +x


### PR DESCRIPTION
This prevents QEMU from creating devices underneath us, which can change
across QEMU versions (see de875be20ca66). To prevent this in the future,
add '-nodefaults' for all invocations of QEMU, not just powerpc64le.

Tested with QEMU 3.1.0, 4.2.0, and 5.0.0-rc2.

NOTE: This is the only architecture that we actually set devices for so
this should be a no-op for everything else but we might add other
devices in the future.