### PR TITLE
boot-qemu.sh: Add the ability to debug with GDB

### DIFF
--- a/boot-qemu-help.txt
+++ b/boot-qemu-help.txt
@@ -25,6 +25,9 @@ Optional parameters:
   -d | --debug:
     Invokes 'set -x' for debugging the script.
 
+  -g | --gdb:
+    Add '-s -S' to the QEMU invocation to allow debugging via GDB.
+
   -h | --help:
     Prints this message then exits.
 

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -181,7 +181,21 @@ function setup_qemu_args() {
 # Invoke QEMU
 function invoke_qemu() {
     ${INTERACTIVE} || QEMU=( timeout "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}" )
-    ${GDB:=false} && QEMU=( "${QEMU[@]}" -s -S )
+    if ${GDB:=false}; then
+        # Print message in bold green
+        printf '\033[01;32m'
+        echo
+        echo "Starting QEMU with GDB connection on port 1234..."
+        echo
+        echo "Use:"
+        echo
+        printf '\ttarget remote :1234\n'
+        echo
+        echo "to connect"
+        echo
+        printf '\033[0m'
+        QEMU=( "${QEMU[@]}" -s -S )
+    fi
 
     set -x
     "${QEMU[@]}" \

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -31,6 +31,10 @@ function parse_parameters() {
             -d|--debug)
                 set -x ;;
 
+            -g|--gdb)
+                GDB=true
+                INTERACTIVE=true ;;
+
             -h|--help)
                 echo
                 cat "${BASE}"/boot-qemu-help.txt
@@ -177,6 +181,7 @@ function setup_qemu_args() {
 # Invoke QEMU
 function invoke_qemu() {
     ${INTERACTIVE} || QEMU=( timeout "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}" )
+    ${GDB:=false} && QEMU=( "${QEMU[@]}" -s -S )
 
     set -x
     "${QEMU[@]}" \


### PR DESCRIPTION
Adding '-s -S' stops the CPU and allows us to connect with GDB via
'target remote :1234'.

This implies '-i' so that the machine does not get killed in the middle
of debugging.