### PR TITLE
boot-qemu.sh: Combine x86 and x86_64 for shared KVM handling

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -180,20 +180,16 @@ function setup_qemu_args() {
             QEMU=(qemu-system-ppc64)
             ;;
 
-        x86)
-            KIMAGE=bzImage
-            QEMU_ARCH_ARGS=(-append "console=ttyS0${RDINIT}" -enable-kvm)
-            QEMU_RAM=512m
-            QEMU=(qemu-system-i386)
-            ;;
-
-        x86_64)
+        x86 | x86_64)
             KIMAGE=bzImage
             QEMU_ARCH_ARGS=(-append "console=ttyS0${RDINIT}")
             # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
             [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] &&
                 QEMU_ARCH_ARGS=("${QEMU_ARCH_ARGS[@]}" -cpu host -d "unimp,guest_errors" -enable-kvm)
-            QEMU=(qemu-system-x86_64)
+            case ${ARCH} in
+                x86) QEMU=(qemu-system-i386) ;;
+                x86_64) QEMU=(qemu-system-x86_64) ;;
+            esac
             ;;
     esac
     checkbin "${QEMU[*]}"


### PR DESCRIPTION
The x86 section unconditionally adds -enable-kvm to the QEMU flags. This
won't work for Travis because it does not have KVM support. The x86_64
section handles this already and the only difference between the x86 and
x86_64 sections is the QEMU binary name. Combine the sections and handle
that so that there is less duplication and everything works properly.