### PR TITLE
run timeout in the foreground so it can be killed

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -207,7 +207,6 @@ function setup_qemu_args() {
 
 # Invoke QEMU
 function invoke_qemu() {
-    ${INTERACTIVE} || QEMU=(timeout --foreground "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}")
     [[ -z ${QEMU_RAM} ]] && QEMU_RAM=512m
     if ${GDB:=false}; then
         while true; do
@@ -243,6 +242,7 @@ function invoke_qemu() {
         done
     fi
 
+    ${INTERACTIVE} || QEMU=(timeout --foreground "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}")
     set -x
     "${QEMU[@]}" \
         "${QEMU_ARCH_ARGS[@]}" \

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -207,7 +207,7 @@ function setup_qemu_args() {
 
 # Invoke QEMU
 function invoke_qemu() {
-    ${INTERACTIVE} || QEMU=(timeout "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}")
+    ${INTERACTIVE} || QEMU=(timeout --foreground "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}")
     [[ -z ${QEMU_RAM} ]] && QEMU_RAM=512m
     if ${GDB:=false}; then
         while true; do


### PR DESCRIPTION
When a kernel is hung, we currently have to wait the timeout to exit,
(or ctrl+z; `pkill timeout; fg`).  For complicated reasons, running timeout
from a shell script won't forward signals to timeout.

Adding --foreground is the simplest option for this to work, via:
https://unix.stackexchange.com/a/233685/388381

See other answers in that thread for *why* this is the case.