### PR TITLE
enable more virtual cores for x86

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -191,7 +191,7 @@ function setup_qemu_args() {
             APPEND_STRING+="console=ttyS0 "
             # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
             [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] &&
-                QEMU_ARCH_ARGS=("${QEMU_ARCH_ARGS[@]}" -cpu host -d "unimp,guest_errors" -enable-kvm -smp $(nproc))
+                QEMU_ARCH_ARGS=("${QEMU_ARCH_ARGS[@]}" -cpu host -d "unimp,guest_errors" -enable-kvm -smp "$(nproc)")
             case ${ARCH} in
                 x86) QEMU=(qemu-system-i386) ;;
                 x86_64) QEMU=(qemu-system-x86_64) ;;

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -191,7 +191,7 @@ function setup_qemu_args() {
             APPEND_STRING+="console=ttyS0 "
             # Use KVM if the processor supports it (first part) and the KVM module is loaded (second part)
             [[ $(grep -c -E 'vmx|svm' /proc/cpuinfo) -gt 0 && $(lsmod 2>/dev/null | grep -c kvm) -gt 0 ]] &&
-                QEMU_ARCH_ARGS=("${QEMU_ARCH_ARGS[@]}" -cpu host -d "unimp,guest_errors" -enable-kvm)
+                QEMU_ARCH_ARGS=("${QEMU_ARCH_ARGS[@]}" -cpu host -d "unimp,guest_errors" -enable-kvm -smp $(nproc))
             case ${ARCH} in
                 x86) QEMU=(qemu-system-i386) ;;
                 x86_64) QEMU=(qemu-system-x86_64) ;;


### PR DESCRIPTION
The unit tests enabled via CONFIG_KCSAN_TEST require >1 CPU to run.
Enable more cpu's via QEMU's `-smp <n>` command line flag.

Not sure if we should just do this for all ARCHs and if we should use a
value like 8 or min(nproc, 8).

Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>