### PR TITLE
qemu: aarch64: switch to -cpu max for PAC/BTI

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -140,7 +140,7 @@ function setup_qemu_args() {
             KIMAGE=Image.gz
             APPEND_STRING+="console=ttyAMA0 "
             QEMU_ARCH_ARGS=(
-                -cpu cortex-a57
+                -cpu max
                 -machine virt)
             QEMU=(qemu-system-aarch64)
             ;;


### PR DESCRIPTION
The PAC/BTI instructions were added in v8.3a/v8.5a.
(See https://reviews.llvm.org/D62609).
Without enabling this cpu, the instructions are treated as NOPS.  Switch
to a CPU that will use these instructions, testing kernel configs
(CONFIG_ARM64_PTR_AUTH, CONFIG_ARM64_BTI) which we will ship and
Android+CrOS as soon as hardware is available.

Suggested-by: Mark Brown <broonie@kernel.org>