### PR TITLE
gdb: require gdb-multiarch for -g

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,7 +27,8 @@ Optional parameters:
     Invokes 'set -x' for debugging the script.
 
   -g | --gdb:
-    Add '-s -S' to the QEMU invocation to allow debugging via GDB.
+    Add '-s -S' to the QEMU invocation to allow debugging via GDB (will invoke
+   `$GDB_BIN` env var else `gdb-multiarch`).
 
   -h | --help:
     Prints this message then exits.

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -227,7 +227,7 @@ function invoke_qemu() {
                 -s -S &
             QEMU_PID=$!
             green "Starting GDB..."
-            gdb "${KBUILD_DIR}/vmlinux" -ex "target remote :1234"
+            "${GDB_BIN:-gdb-multiarch}" "${KBUILD_DIR}/vmlinux" -ex "target remote :1234"
             red "Killing QEMU..."
             kill -9 "${QEMU_PID}"
             wait "${QEMU_PID}" 2>/dev/null


### PR DESCRIPTION
Since `gdb` likely was only configured for the those triple.