### PR TITLE
boot-qemu.sh: Expect uImage for ppc32

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -156,6 +156,7 @@ function setup_qemu_args() {
 
         ppc32)
             ARCH=powerpc
+            KIMAGE=uImage
             APPEND_STRING+="console=ttyS0 "
             QEMU_ARCH_ARGS=(
                 -machine bamboo


### PR DESCRIPTION
zImage has always been a hardlink to uImage but as of a refactoring in
5.8-rc1, that is no longer guaranteed to be the case. Explicitly use the
uImage, which will always work for QEMU.

Link: https://lore.kernel.org/linuxppc-dev/87bllidmk4.fsf@mpe.ellerman.id.au/