### PR TITLE
boot-qemu.sh: Allow the user to supply a kernel image directly

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -19,10 +19,11 @@ Required parameters:
        * x86
        * x86_64
 
-  -k | --kbuild-folder:
-    The kernel build folder, as an absolute path or relative path
-    from wherever the script is being run. This is wherever the
-    compiled vmlinux image lives, not the architecture's boot folder.
+  -k | --kernel-location:
+    The kernel location, which can either be the kernel image itself or
+    the root of the kernel build output folder. Either option can be
+    passed as an absolute path or relative path from wherever the script
+    is being run.
 
 Optional parameters:
   -d | --debug:


### PR DESCRIPTION
There are times where supplying a kernel image directly makes more sense
than providing the build output folder. For example, when using tuxmake,
the build output folder is automatically cleaned up, leaving just the
compiled artifacts. To boot kernels in this way, one would have to make
a fake boot folder and copy the image to it.

Convert '-k' to either take a kernel image directly or the kernel build
output folder.