### PR TITLE
boot-utils: Add '--use-cbl-qemu'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+qemu-binaries/
 rootfs.cpio

--- a/README.txt
+++ b/README.txt
@@ -49,3 +49,10 @@ Optional parameters:
     QEMU machine. Depending on the power of the host machine, this might
     not be long enough for a kernel to boot so this allows that timeout
     to be configured. Takes the value passed to timeout (e.g. 30s or 4m).
+
+  --use-cbl-qemu (only relevant with '-a s390'):
+    Currently, s390 only boots with patches that are available in QEMU
+    master. It could take a while for those patches to make it to various
+    distribution versions of qemu-system-s390 so we provide a copy of it
+    at https://github.com/ClangBuiltLinux/qemu-binaries. This option
+    downloads that repo here and decompresses the binary to use it.

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -72,6 +72,10 @@ function parse_parameters() {
                 shift && TIMEOUT=${1}
                 ;;
 
+            --use-cbl-qemu)
+                USE_CBL_QEMU=true
+                ;;
+
             *)
                 die "Invalid parameter '${1}'"
                 ;;
@@ -208,6 +212,18 @@ function setup_qemu_args() {
             KIMAGE=bzImage
             QEMU_ARCH_ARGS=(-M s390-ccw-virtio)
             QEMU=(qemu-system-s390x)
+            if ${USE_CBL_QEMU:-false}; then
+                QEMU_BINARIES=${BASE}/qemu-binaries
+
+                green "Downloading or updating qemu-binaries..."
+                [[ -d ${QEMU_BINARIES} ]] || git clone https://github.com/ClangBuiltLinux/qemu-binaries "${QEMU_BINARIES}"
+                git -C "${QEMU_BINARIES}" pull --rebase
+
+                QEMU_BIN=${QEMU_BINARIES}/bin
+                QEMU_S390=${QEMU_BIN}/${QEMU[*]}
+                zstd -q -d "${QEMU_S390}".zst -o "${QEMU_S390}" || die "Error decompressing qemu-system-s390x"
+                export PATH=${QEMU_BIN}:${PATH}
+            fi
             ;;
 
         x86 | x86_64)


### PR DESCRIPTION
We need to do this in order to boot s390 kernels in our CI. The qemu
binaries are hosted in a separate repo to keep things reasonable in
terms of file size.

This is part two in resolving https://github.com/ClangBuiltLinux/continuous-integration2/issues/42.