### PR TITLE
boot-utils: Add RISC-V to use '--use-cbl-qemu'

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -50,9 +50,14 @@ Optional parameters:
     not be long enough for a kernel to boot so this allows that timeout
     to be configured. Takes the value passed to timeout (e.g. 30s or 4m).
 
-  --use-cbl-qemu (only relevant with '-a s390'):
-    Currently, s390 only boots with patches that are available in QEMU
-    master. It could take a while for those patches to make it to various
-    distribution versions of qemu-system-s390 so we provide a copy of it
-    at https://github.com/ClangBuiltLinux/qemu-binaries. This option
-    downloads that repo here and decompresses the binary to use it.
+  --use-cbl-qemu (only relevant with '-a riscv' or '-a s390'):
+    Certain distribution versions of qemu-system-riscv have an issue
+    with shutting down. This was fixed in QEMU upstream so an upstream
+    binary is provided in case you are affected by it.
+
+    s390 only boots with patches that are available in QEMU master. It
+    could take a while for those patches to make it to various
+    distribution versions of qemu-system-s390.
+
+    This option downloads https://github.com/ClangBuiltLinux/qemu-binaries
+    here and decompresses the binary to use it.

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -212,18 +212,6 @@ function setup_qemu_args() {
             KIMAGE=bzImage
             QEMU_ARCH_ARGS=(-M s390-ccw-virtio)
             QEMU=(qemu-system-s390x)
-            if ${USE_CBL_QEMU:-false}; then
-                QEMU_BINARIES=${BASE}/qemu-binaries
-
-                green "Downloading or updating qemu-binaries..."
-                [[ -d ${QEMU_BINARIES} ]] || git clone https://github.com/ClangBuiltLinux/qemu-binaries "${QEMU_BINARIES}"
-                git -C "${QEMU_BINARIES}" pull --rebase
-
-                QEMU_BIN=${QEMU_BINARIES}/bin
-                QEMU_S390=${QEMU_BIN}/${QEMU[*]}
-                zstd -q -d "${QEMU_S390}".zst -o "${QEMU_S390}" || die "Error decompressing qemu-system-s390x"
-                export PATH=${QEMU_BIN}:${PATH}
-            fi
             ;;
 
         x86 | x86_64)
@@ -238,6 +226,18 @@ function setup_qemu_args() {
             esac
             ;;
     esac
+    if ${USE_CBL_QEMU:-false} && [[ ${ARCH} = "riscv" || ${ARCH} = "s390" ]]; then
+        QEMU_BINARIES=${BASE}/qemu-binaries
+
+        green "Downloading or updating qemu-binaries..."
+        [[ -d ${QEMU_BINARIES} ]] || git clone https://github.com/ClangBuiltLinux/qemu-binaries "${QEMU_BINARIES}"
+        git -C "${QEMU_BINARIES}" pull --rebase
+
+        QEMU_BIN=${QEMU_BINARIES}/bin
+        QEMU_BINARY=${QEMU_BIN}/${QEMU[*]}
+        zstd -q -d "${QEMU_BINARY}".zst -o "${QEMU_BINARY}" || die "Error decompressing ${QEMU[*]}"
+        export PATH=${QEMU_BIN}:${PATH}
+    fi
     checkbin "${QEMU[*]}"
 
     # If '-k' is an path that ends in the kernel image, we can just use it directly


### PR DESCRIPTION
Part 2 of resolving https://github.com/ClangBuiltLinux/continuous-integration2/issues/72