### PR TITLE
boot-utils: Only allow '--use-cbl-qemu' with s390

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -67,11 +67,7 @@ Optional parameters:
     not be long enough for a kernel to boot so this allows that timeout
     to be configured. Takes the value passed to timeout (e.g. 30s or 4m).
 
-  --use-cbl-qemu (only relevant with '-a riscv' or '-a s390'):
-    Certain distribution versions of qemu-system-riscv have an issue
-    with shutting down. This was fixed in QEMU upstream so an upstream
-    binary is provided in case you are affected by it.
-
+  --use-cbl-qemu (only relevant with '-a s390'):
     s390 only boots with patches that are available in QEMU master. It
     could take a while for those patches to make it to various
     distribution versions of qemu-system-s390.

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -267,7 +267,7 @@ function setup_qemu_args() {
             esac
             ;;
     esac
-    if ${USE_CBL_QEMU:-false} && [[ ${ARCH} = "riscv" || ${ARCH} = "s390" ]]; then
+    if ${USE_CBL_QEMU:-false} && [[ ${ARCH} = "s390" ]]; then
         QEMU_BINARIES=${BASE}/qemu-binaries
 
         green "Downloading or updating qemu-binaries..."


### PR DESCRIPTION
RISC-V no longer needs it.

Link: https://bugs.launchpad.net/bugs/1914883