### PR TITLE
overlay: Exit rcS script so it only runs once

### DIFF
--- a/buildroot/overlay-poweroff/etc/init.d/S50yolo
+++ b/buildroot/overlay-poweroff/etc/init.d/S50yolo
@@ -2,3 +2,5 @@
 
 cat /proc/version
 poweroff
+
+exit 0

--- a/buildroot/overlay-reboot/etc/init.d/S50yolo
+++ b/buildroot/overlay-reboot/etc/init.d/S50yolo
@@ -2,3 +2,5 @@
 
 cat /proc/version
 reboot
+
+exit 0


### PR DESCRIPTION
Ever wondered why the /proc/version output appears in the logs twice?

I discovered that if we exit from the scripts instead of doing nothing,
it only appears once! I could speculate what's going on but I don't
precisely know.

Signed-off-by: Joel Stanley <joel@jms.id.au>