### PR TITLE
buildroot: Check init.d action to avoid double version print out

### DIFF
--- a/buildroot/overlay-poweroff/etc/init.d/S50yolo
+++ b/buildroot/overlay-poweroff/etc/init.d/S50yolo
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-cat /proc/version
-poweroff
+if [ "$1" = "start" ]; then
+    cat /proc/version
+    poweroff
+fi

--- a/buildroot/overlay-reboot/etc/init.d/S50yolo
+++ b/buildroot/overlay-reboot/etc/init.d/S50yolo
@@ -1,4 +1,6 @@
 #!/bin/sh
 
-cat /proc/version
-reboot
+if [ "$1" = "start" ]; then
+    cat /proc/version
+    reboot
+fi


### PR DESCRIPTION
Currently, when booting the images, the version string prints out twice.
This is because these scripts are called twice: once with the "start"
action and again with the "stop" action.

To avoid this, just run the contents of the script when the service is
starting.

Given that this is a purely cosmetic issue, I do not think that it is
worth rebuilding the images over.

Closes: #41