### PR TITLE
debian/build.sh: qemu-debootstrap -> debootstrap

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -105,9 +105,9 @@ function reality_checks() {
     # Some tools are in /usr/sbin or /sbin but they might not be in PATH by default
     [[ ${PATH} =~ /sbin ]] || PATH=${PATH}:/usr/sbin:/sbin
     is_available blkid
+    is_available debootstrap
     is_available findmnt
     is_available mkfs.ext4
-    is_available qemu-debootstrap
     is_available qemu-img
 
     # Default values
@@ -149,7 +149,7 @@ function create_img() {
         sudo
         vim
     )
-    qemu-debootstrap --arch "${DEB_ARCH}" --include="${PACKAGES[*]//${IFS:0:1}/,}" "${DEB_VERSION}" "${MOUNT_DIR}" || exit ${?}
+    debootstrap --arch "${DEB_ARCH}" --include="${PACKAGES[*]//${IFS:0:1}/,}" "${DEB_VERSION}" "${MOUNT_DIR}" || exit ${?}
 
     # Setup user account
     chroot "${MOUNT_DIR}" bash -c "useradd -m -G sudo ${DEB_USER} -s /bin/bash && echo ${DEB_USER}:${DEB_PASS} | chpasswd"


### PR DESCRIPTION
qemu-debootstrap has been deprecated in favor of just running
debootstrap due to the use of the "F" flag with binfmt_misc.

https://salsa.debian.org/qemu-team/qemu/-/commit/9899b1723119e57354c5d8e6f68f15ed762bd570

This makes it easier for other distributions to run the script because
debootstrap is usually available from the package manager but
qemu-debootstrap is a part of Debian's qemu-user-static package.