### PR TITLE
boot-qemu.sh: Do not set earlycon for arm32_v6

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -144,7 +144,6 @@ function setup_qemu_args() {
             ;;
 
         arm32_v6)
-            APPEND_STRING+="earlycon "
             ARCH=arm
             DTB=aspeed-bmc-opp-romulus.dtb
             QEMU_ARCH_ARGS=(


### PR DESCRIPTION
Otherwise, the console changes midboot and we lose output, making it
look like a hang.