### PR TITLE
boot-qemu.sh: Use stdbuf instead of unbuffer

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -382,7 +382,7 @@ function invoke_qemu() {
         done
     fi
 
-    ${INTERACTIVE} || QEMU=(timeout --foreground "${TIMEOUT:=3m}" unbuffer "${QEMU[@]}")
+    ${INTERACTIVE} || QEMU=(timeout --foreground "${TIMEOUT:=3m}" stdbuf -oL -eL "${QEMU[@]}")
     set -x
     "${QEMU[@]}" \
         "${QEMU_ARCH_ARGS[@]}" \


### PR DESCRIPTION
To avoid needing the "expect" package, use "stdbuf" from coreutils to control output buffering. While at it, switch to line-buffering to avoid stdout/stderr mixing.