### PR TITLE
boot-utils: Remove '--use-cbl-qemu'

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -82,11 +82,3 @@ Optional parameters:
     QEMU machine. Depending on the power of the host machine, this might
     not be long enough for a kernel to boot so this allows that timeout
     to be configured. Takes the value passed to timeout (e.g. 30s or 4m).
-
-  --use-cbl-qemu (only relevant with '-a s390'):
-    s390 only boots with patches that are available in QEMU master. It
-    could take a while for those patches to make it to various
-    distribution versions of qemu-system-s390.
-
-    This option downloads https://github.com/ClangBuiltLinux/qemu-binaries
-    here and decompresses the binary to use it.

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -85,10 +85,6 @@ function parse_parameters() {
                 shift && TIMEOUT=${1}
                 ;;
 
-            --use-cbl-qemu)
-                USE_CBL_QEMU=true
-                ;;
-
             *)
                 die "Invalid parameter '${1}'"
                 ;;
@@ -292,18 +288,6 @@ function setup_qemu_args() {
             esac
             ;;
     esac
-    if ${USE_CBL_QEMU:-false} && [[ ${ARCH} = "s390" ]]; then
-        QEMU_BINARIES=${BASE}/qemu-binaries
-
-        green "Downloading or updating qemu-binaries..."
-        [[ -d ${QEMU_BINARIES} ]] || git clone https://github.com/ClangBuiltLinux/qemu-binaries "${QEMU_BINARIES}"
-        git -C "${QEMU_BINARIES}" pull --rebase
-
-        QEMU_BIN=${QEMU_BINARIES}/bin
-        QEMU_BINARY=${QEMU_BIN}/${QEMU[*]}
-        zstd -q -d "${QEMU_BINARY}".zst -o "${QEMU_BINARY}" || die "Error decompressing ${QEMU[*]}"
-        export PATH=${QEMU_BIN}:${PATH}
-    fi
     checkbin "${QEMU[*]}"
 
     # If '-k' is an path that ends in the kernel image, we can just use it directly


### PR DESCRIPTION
This option was intended for CI usage, which has now moved to a
container based workflow, so that we can easily get access to newer QEMU
versions, which makes this option obsolete. Remove it.