### PR TITLE
boot-qemu.sh: Add 'arm' as an alias for 'arm32_v7'

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,6 +8,7 @@ Required parameters:
        * arm32_v5
        * arm32_v6
        * arm32_v7
+       * arm (shorthand for arm32_v7)
        * arm64
        * arm64be
        * m68k

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -39,7 +39,7 @@ function parse_parameters() {
             -a | --arch | --architecture)
                 shift
                 case ${1} in
-                    arm32_v5 | arm32_v6 | arm32_v7 | arm64 | arm64be | m68k | mips | mipsel | ppc32 | ppc64 | ppc64le | riscv | s390 | x86 | x86_64) ARCH=${1} ;;
+                    arm | arm32_v5 | arm32_v6 | arm32_v7 | arm64 | arm64be | m68k | mips | mipsel | ppc32 | ppc64 | ppc64le | riscv | s390 | x86 | x86_64) ARCH=${1} ;;
                     *) die "Invalid --arch value '${1}'" ;;
                 esac
                 ;;
@@ -158,7 +158,7 @@ function setup_qemu_args() {
             QEMU=(qemu-system-arm)
             ;;
 
-        arm32_v7)
+        arm | arm32_v7)
             ARCH=arm
             APPEND_STRING+="console=ttyAMA0 earlycon "
             # https://lists.nongnu.org/archive/html/qemu-discuss/2018-08/msg00030.html


### PR DESCRIPTION
This is an opinionated change but one I think most people will agree
with. I boot test multi_v7_defconfig variants more than either of the
other 32-bit ARM configurations we test and remembering to put the
'32_v7' part is rather annoying. Add 'arm' as a valid '-a' value so that
it works the same as 'arm32_v7'.
