### PR TITLE
boot-qemu.sh: Do not set '-cpu' for 32-bit x86

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -300,7 +300,7 @@ function setup_qemu_args() {
                     -smp "${SMP:-$(nproc)}"
                 )
             else
-                QEMU_ARCH_ARGS=(-cpu Nehalem)
+                [[ ${ARCH} = "x86_64" ]] && QEMU_ARCH_ARGS=(-cpu Nehalem)
             fi
             case ${ARCH} in
                 x86) QEMU=(qemu-system-i386) ;;


### PR DESCRIPTION
This causes warnings when using TCG (i.e. no KVM):

```
qemu-system-i386: warning: TCG doesn't support requested feature: CPUID.80000001H:EDX.syscall [bit 11]
qemu-system-i386: warning: TCG doesn't support requested feature: CPUID.80000001H:EDX.lm [bit 29]
```

The '-cpu' flag was added to support using prebuilt GCC toolchains in
Buildroot in commit 344ff00 ("boot-qemu.sh: Use Nehalem for non-KVM boot
on x86_64") but I forgot that this block applies to both 32-bit and
64-bit x86.

Given that Nehalem is a 64-bit microarchitecture, this flag should only
be supplied when booting an x86_64 kernel, which removes the warning for
`-a x86`.
