### PR TITLE
Improve default '-smp' value

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -246,9 +246,13 @@ function setup_qemu_args() {
             else
                 QEMU_ARCH_ARGS+=(-machine "virtualization=true")
             fi
+            # Give the machine more cores and memory when booting Debian to
+            # improve performance
             if ${DEBIAN}; then
-                # Booting is so slow without these
                 QEMU_RAM=2G
+                # Do not add '-smp' if it is present at this point, as that
+                # means that KVM is being used, which will already have a
+                # suitable number of cores
                 if ! echo "${QEMU_ARCH_ARGS[*]}" | grep -q smp; then
                     QEMU_ARCH_ARGS+=(-smp "${SMP:-4}")
                 fi

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -222,6 +222,7 @@ function setup_qemu_args() {
                 QEMU_ARCH_ARGS+=(
                     -cpu "host,aarch64=off"
                     -enable-kvm
+                    -smp "${SMP:-$(get_default_smp_value)}"
                 )
                 QEMU=(qemu-system-aarch64)
             else
@@ -238,14 +239,19 @@ function setup_qemu_args() {
                 -machine "virt,gic-version=max"
             )
             if [[ "$(uname -m)" = "aarch64" && -e /dev/kvm ]] && ${KVM}; then
-                QEMU_ARCH_ARGS+=(-enable-kvm)
+                QEMU_ARCH_ARGS+=(
+                    -enable-kvm
+                    -smp "${SMP:-$(get_default_smp_value)}"
+                )
             else
                 QEMU_ARCH_ARGS+=(-machine "virtualization=true")
             fi
             if ${DEBIAN}; then
                 # Booting is so slow without these
                 QEMU_RAM=2G
-                QEMU_ARCH_ARGS+=(-smp "${SMP:-4}")
+                if ! echo "${QEMU_ARCH_ARGS[*]}" | grep -q smp; then
+                    QEMU_ARCH_ARGS+=(-smp "${SMP:-4}")
+                fi
             fi
             QEMU=(qemu-system-aarch64)
             ;;


### PR DESCRIPTION
This series implements a heuristic for the default '-smp' value when KVM is used and uses '-smp' for arm and arm64 KVM for better performance.
