### PR TITLE
boot-qemu.sh: arm64: Pass 'lpa2=off' when necessary

### DIFF
--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -267,9 +267,16 @@ function setup_qemu_args() {
         arm64 | arm64be)
             ARCH=arm64
             KIMAGE=Image.gz
+            QEMU=(qemu-system-aarch64)
+            get_full_kernel_path
+            # https://gitlab.com/qemu-project/qemu/-/commit/69b2265d5fe8e0f401d75e175e0a243a7d505e53
+            if [[ $(get_lnx_ver_code gzip -c -d "${KERNEL}") -lt 512000 ]] &&
+                [[ $(get_qemu_ver_code) -ge 602050 ]]; then
+                LPA2=,lpa2=off
+            fi
             APPEND_STRING+="console=ttyAMA0 earlycon "
             QEMU_ARCH_ARGS=(
-                -cpu max
+                -cpu "max${LPA2}"
                 -machine "virt,gic-version=max"
             )
             if [[ "$(uname -m)" = "aarch64" && -e /dev/kvm ]] && ${KVM}; then
@@ -291,7 +298,6 @@ function setup_qemu_args() {
                     QEMU_ARCH_ARGS+=(-smp "${SMP:-4}")
                 fi
             fi
-            QEMU=(qemu-system-aarch64)
             ;;
 
         m68k)

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -170,6 +170,13 @@ function get_full_kernel_path() {
     [[ -f ${KERNEL} ]] || die "${KERNEL} does not exist!"
 }
 
+# Print QEMU version as a five or six digit number
+function get_qemu_ver_code() {
+    QEMU_VER=$("${QEMU[@]}" --version | head -1 | cut -d ' ' -f 4)
+    IFS=. read -ra QEMU_VER <<<"${QEMU_VER}"
+    printf "%d%02d%02d" "${QEMU_VER[@]}"
+}
+
 # Boot QEMU
 function setup_qemu_args() {
     # All arm32_* options share the same rootfs, under images/arm

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -177,6 +177,14 @@ function get_qemu_ver_code() {
     printf "%d%02d%02d" "${QEMU_VER[@]}"
 }
 
+# Print Linux version of a kernel image as a six or seven digit number
+# Takes the command to dump a kernel image to stdout as its argument
+function get_lnx_ver_code() {
+    LINUX_VER="$("${@}" |& strings |& grep -E "^Linux version [0-9]\.[0-9]+\.[0-9]+" | cut -d ' ' -f 3 | cut -d - -f 1)"
+    IFS=. read -ra LINUX_VER <<<"${LINUX_VER}"
+    printf "%d%02d%03d" "${LINUX_VER[@]}"
+}
+
 # Boot QEMU
 function setup_qemu_args() {
     # All arm32_* options share the same rootfs, under images/arm

--- a/boot-qemu.sh
+++ b/boot-qemu.sh
@@ -170,19 +170,23 @@ function get_full_kernel_path() {
     [[ -f ${KERNEL} ]] || die "${KERNEL} does not exist!"
 }
 
-# Print QEMU version as a five or six digit number
+# Takes a version (x.y.z) and prints a six or seven digit number
+# For example, QEMU 6.2.50 would become 602050 and Linux 5.10.100
+# would become 510100
+function print_ver_code() {
+    IFS=. read -ra VER_CODE <<<"${1}"
+    printf "%d%02d%03d" "${VER_CODE[@]}"
+}
+
+# Print QEMU version as a six or seven digit number
 function get_qemu_ver_code() {
-    QEMU_VER=$("${QEMU[@]}" --version | head -1 | cut -d ' ' -f 4)
-    IFS=. read -ra QEMU_VER <<<"${QEMU_VER}"
-    printf "%d%02d%02d" "${QEMU_VER[@]}"
+    print_ver_code "$("${QEMU[@]}" --version | head -1 | cut -d ' ' -f 4)"
 }
 
 # Print Linux version of a kernel image as a six or seven digit number
 # Takes the command to dump a kernel image to stdout as its argument
 function get_lnx_ver_code() {
-    LINUX_VER="$("${@}" |& strings |& grep -E "^Linux version [0-9]\.[0-9]+\.[0-9]+" | cut -d ' ' -f 3 | cut -d - -f 1)"
-    IFS=. read -ra LINUX_VER <<<"${LINUX_VER}"
-    printf "%d%02d%03d" "${LINUX_VER[@]}"
+    print_ver_code "$("${@}" |& strings |& grep -E "^Linux version [0-9]\.[0-9]+\.[0-9]+" | cut -d ' ' -f 3 | cut -d - -f 1)"
 }
 
 # Boot QEMU


### PR DESCRIPTION
Starting with QEMU commit 69b2265d5fe8e, aarch64 kernels older than
5.12.0 do not boot without "lpa2=off". Add this parameter when booting a
kernel older than this version using a version of QEMU that has this
commit.

We cannot universally pass this for all QEMU versions because the
property is not recognized on older version:

qemu-system-aarch64: can't apply global max-arm-cpu.lpa2=off: Property 'max-arm-cpu.lpa2' not found

We could pass this for all kernel versions but we miss out on testing a
default QEMU change.

The first three commits add the individual functions that are needed by the
last commit for ease of reviewing.

Link: https://gitlab.com/qemu-project/qemu/-/commit/69b2265d5fe8e0f401d75e175e0a243a7d505e53
