### PR TITLE
boot-uml.sh: Remove exec hack

### DIFF
--- a/boot-uml.sh
+++ b/boot-uml.sh
@@ -30,10 +30,7 @@ function decomp_rootfs() {
 }
 
 function execute_kernel() {
-    # exec is needed to avoid a "Killed" message when the kernel shuts down:
-    # https://github.com/ClangBuiltLinux/boot-utils/issues/60
-    # Nothing runs after this command so it is okay for it to replace this process.
-    exec "$KERNEL" ubd0="$rootfs" "${kernel_args[@]}"
+    "$KERNEL" ubd0="$rootfs" "${kernel_args[@]}"
 }
 
 parse_parameters "$@"


### PR DESCRIPTION
A fix for this issue has been merged into mainline and it has been in
-next for a few days already.

Closes: https://github.com/ClangBuiltLinux/boot-utils/issues/60
Link: https://git.kernel.org/linus/57ae0b67b747031bc41fb44643aa5344ab58607e
