### PR TITLE
boot-utils.py: Fix searching for Linux kernel version numbers

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -4,6 +4,7 @@ import argparse
 import os
 from pathlib import Path
 import platform
+import re
 import shutil
 import subprocess
 
@@ -326,7 +327,7 @@ def get_linux_ver_code(decomp_cmd):
 
     linux_version = None
     for line in strings.stdout.decode("UTF-8").split("\n"):
-        if "Linux version" in line:
+        if re.search(r"Linux version \d\.\d+\.\d+", line):
             # "Linux version x.y.z-<localversion> ..." -> "x.y.z-<localversion>" -> "x.y.z" -> ['x', 'y', 'z']
             linux_version = line.split(" ")[2].split("-")[0].split(".")
             break


### PR DESCRIPTION
CI reported a crash when attempting to boot arm64 kernels:

```
  Traceback (most recent call last):
    File ".../boot-qemu.py", line 727, in <module>
      cfg = get_qemu_args(cfg)
    File ".../boot-qemu.py", line 451, in get_qemu_args
      linux_ver_code = get_linux_ver_code(gzip_kernel_cmd)
    File ".../boot-qemu.py", line 338, in get_linux_ver_code
      return create_version_code(linux_version)
    File ".../boot-qemu.py", line 262, in create_version_code
      major, minor, patch = [int(version[i]) for i in (0, 1, 2)]
    File ".../boot-qemu.py", line 262, in <listcomp>
      major, minor, patch = [int(version[i]) for i in (0, 1, 2)]
  ValueError: invalid literal for int() with base 10: '%s'
```

Looking at the strings output reveals:

```
  $ gzip -d -c Image.gz &| strings &| grep "Linux version "
  Linux version %s (%s)
  Linux version 4.19.254 (tuxmake@tuxmake) (Debian clang version 14.0.6-++20220622053050+f28c006a5895-1~exp1~20220622173135.152, Debian LLD 14.0.6) #1 SMP PREEMPT @1659593940
```

Use `re.search()` plus a regular expression for a more precise match. I
had originally tried to do this but I could not get it to work for some
reason. I tested this against all the kernels that had issues in CI with
no further issues.
