### PR TITLE
boot-utils: Flush print commands to ensure output is properly ordered

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -645,7 +645,7 @@ def pretty_print_qemu_cmd(qemu_cmd):
             qemu_cmd_pretty += " {}".format(element.split("/")[-1])
         else:
             qemu_cmd_pretty += " {}".format(element)
-    print("$ {}".format(qemu_cmd_pretty.strip()))
+    print("$ {}".format(qemu_cmd_pretty.strip()), flush=True)
 
 
 def launch_qemu(cfg):

--- a/utils.py
+++ b/utils.py
@@ -73,7 +73,7 @@ def green(string):
     Parameters:
         string (str): String to print in bold green.
     """
-    print("\n\033[01;32m{}\033[0m".format(string))
+    print("\n\033[01;32m{}\033[0m".format(string), flush=True)
 
 
 def red(string):
@@ -83,4 +83,4 @@ def red(string):
     Parameters:
         string (str): String to print in bold red.
     """
-    print("\n\033[01;31m{}\033[0m".format(string))
+    print("\n\033[01;31m{}\033[0m".format(string), flush=True)


### PR DESCRIPTION
Otherwise, when running non-interactively (such as through GitHub
Actions), the output from these print statements might not appear before
QEMU's output, making it hard to decipher what has gone wrong.
