### PR TITLE
boot-qemu: Move from 'powernv8' to 'powernv' machine

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -507,7 +507,7 @@ def get_qemu_args(cfg):
         qemu = "qemu-system-ppc64"
         qemu_args += ["-device", "ipmi-bmc-sim,id=bmc0"]
         qemu_args += ["-device", "isa-ipmi-bt,bmc=bmc0,irq=10"]
-        qemu_args += ["-machine", "powernv8"]
+        qemu_args += ["-machine", "powernv"]
         ram = "2G"
 
     elif arch == "riscv":


### PR DESCRIPTION
As pointed out by Cédric [1], POWER8 is a little old. We moved from
POWER9 to POWER8 in commit 29f7dba ("boot-qemu.sh: Specify POWER8 CPUs
for ppc64 and ppc64le") because of the rootfs, which works fine on a
POWER9 machine as well, which is the current meaning of the 'powernv'
machine. This has been tested with all the images from
continuous-integration2 to ensure it is safe for all the versions we
test.

[1]: https://github.com/ClangBuiltLinux/boot-utils/commit/a0540ceaccd97e92d2c2eb0ea504e762a174171b#r83919704
