### PR TITLE
boot-qemu.py: Fix get_linux_ver_code() when CONFIG_LOCALVERSION_AUTO is not set

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -328,8 +328,7 @@ def get_linux_ver_code(decomp_cmd):
     linux_version = None
     for line in strings.stdout.decode("UTF-8").split("\n"):
         if re.search(r"Linux version \d+\.\d+\.\d+", line):
-            # "Linux version x.y.z-<localversion> ..." -> "x.y.z-<localversion>" -> "x.y.z" -> ['x', 'y', 'z']
-            linux_version = line.split(" ")[2].split("-")[0].split(".")
+            linux_version = re.search(r"\d+\.\d+\.\d+", line)[0].split(".")
             break
     if not linux_version:
         kernel_path = decomp_cmd[-1]


### PR DESCRIPTION
When CONFIG_LOCALVERSION_AUTO is not set, the Linux version string may be
"Linux version x.y.z+", which is not handled gracefully by the script:

```
  Traceback (most recent call last):
    File ".../boot-utils/boot-qemu.py", line 726, in <module>
      cfg = get_qemu_args(cfg)
    File ".../boot-utils/boot-qemu.py", line 452, in get_qemu_args
      linux_ver_code = get_linux_ver_code(gzip_kernel_cmd)
    File ".../boot-utils/boot-qemu.py", line 339, in get_linux_ver_code
      return create_version_code(linux_version)
    File ".../boot-utils/boot-qemu.py", line 263, in create_version_code
      major, minor, patch = [int(version[i]) for i in (0, 1, 2)]
    File ".../boot-utils/boot-qemu.py", line 263, in <listcomp>
      major, minor, patch = [int(version[i]) for i in (0, 1, 2)]
  ValueError: invalid literal for int() with base 10: '0+'
```

Use `re.search()` for a more specific match, which ends up simplifying the
logic to the point of not needing a comment.