### PR TITLE
Macos

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -326,7 +326,7 @@ def get_linux_ver_code(decomp_cmd):
                              input=decomp.stdout)
 
     linux_version = None
-    for line in strings.stdout.decode("UTF-8").split("\n"):
+    for line in strings.stdout.decode("UTF-8", "ignore").split("\n"):
         if re.search(r"Linux version \d+\.\d+\.\d+", line):
             linux_version = re.search(r"\d+\.\d+\.\d+", line)[0].split(".")
             break

--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -195,7 +195,7 @@ def get_smp_value(args):
 
     # Use the minimum of the number of usable processors for the script or
     # CONFIG_NR_CPUS.
-    usable_cpus = len(os.sched_getaffinity(0))
+    usable_cpus = os.cpu_count()
     return min(usable_cpus, config_nr_cpus)
 
 


### PR DESCRIPTION
Fix a few bugs so we can use this on macOS.  Boot tested an aarch64 build.

I also needed to install `coreutils` then add something to my `~/.zshrc` so that
`timeout` would be in my `$PATH` without a `g` prefix.

```sh
$ brew install coreutils
$ echo 'PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"' >> ~/.zshrc
```