### PR TITLE
boot-qemu.py: Combine aarch64 machine flags

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -434,7 +434,7 @@ def get_qemu_args(cfg):
         kernel_arch = "arm64"
         kernel_image = "Image.gz"
         qemu = "qemu-system-aarch64"
-        qemu_args += ["-machine", "virt,gic-version=max"]
+        machine = "virt,gic-version=max"
 
         if not use_kvm:
             cpu = "max"
@@ -458,7 +458,11 @@ def get_qemu_args(cfg):
                 cpu += ",pauth-impdef=true"
 
             qemu_args += ["-cpu", cpu]
-            qemu_args += ["-machine", "virtualization=true"]
+            # Boot with VHE emulation, which allows the kernel to run at EL2.
+            # KVM does not emulate VHE, so this cannot be unconditional.
+            machine += ",virtualization=true"
+
+        qemu_args += ["-machine", machine]
 
     elif arch == "m68k":
         append += " console=ttyS0,115200"


### PR DESCRIPTION
Two `-machine` arguments looks odd, especially since the `gic-version`
parameter is specified on the first `-machine` instance.

Append `virtualization=true` to the existing machine string in a similar
manner to `gic-version` to keep everything uniform. Additionally, add a
comment around why and where `virtualization=true` is specified.
