### PR TITLE
boot-qemu.py: Add support for booting arm64 and x86_64 guests under UEFI

### DIFF
--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,3 +1,5 @@
-debian.img
+efi.img
+efivars.img
 rootfs.cpio
 rootfs.ext4
+OVMF_VARS.fd

--- a/utils.py
+++ b/utils.py
@@ -84,3 +84,13 @@ def red(string):
         string (str): String to print in bold red.
     """
     print(f"\n\033[01;31m{string}\033[0m", flush=True)
+
+
+def yellow(string):
+    """
+    Prints string in bold yellow.
+
+    Parameters:
+        string (str): String to print in bold yellow.
+    """
+    print(f"\n\033[01;33m{string}\033[0m", flush=True)


### PR DESCRIPTION
Booting under UEFI can expose potential issues that will impact real
hardware, like CFI failures. Add support for booting under UEFI with
arm64 and x86_64 by searching for firmare on the user's system, copying
and modifying it as necessary, then passing it along to QEMU.

This is deliberately a separate option that is off by default, as I am
not sure we can turn this on by default without regressing older trees
or toolchains. It has only been tested with tip of tree Linux and LLVM.

Closes: https://github.com/ClangBuiltLinux/boot-utils/issues/14
