### PR TITLE
Add support for mounting a shared folder between the host and guest via virtiofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 qemu-binaries/
 *.pyc
+shared/
+.vfsd.*

--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -886,6 +886,7 @@ def launch_qemu_fg(cfg):
         cfg (dict): The configuration dictionary generated with setup_cfg().
     """
     interactive = cfg["interactive"]
+    kernel_location = cfg["kernel_location"]
     qemu_cmd = cfg["qemu_cmd"] + ["-serial", "mon:stdio"]
     share_folder_with_guest = cfg["share_folder_with_guest"]
     timeout = cfg["timeout"]
@@ -897,6 +898,16 @@ def launch_qemu_fg(cfg):
         share_folder_with_guest = False
 
     if share_folder_with_guest:
+        if not get_config_val(kernel_location, 'CONFIG_VIRTIO_FS'):
+            utils.yellow(
+                'CONFIG_VIRTIO_FS may not be enabled in your configuration, shared folder may not work...'
+            )
+
+        # Print information about using shared folder
+        utils.green('To mount shared folder in guest (e.g. to /mnt/shared):')
+        utils.green('\t/ # mkdir /mnt/shared')
+        utils.green('\t/ # mount -t virtiofs shared /mnt/shared')
+
         shared_folder.mkdir(exist_ok=True, parents=True)
 
         virtiofsd_log = base_folder.joinpath('.vfsd.log')

--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -380,13 +380,11 @@ def get_efi_args(guest_arch):
             Path("edk2/aarch64/QEMU_EFI.fd"),  # Arch Linux (current)
             Path("edk2-armvirt/aarch64/QEMU_EFI.fd"),  # Arch Linux (old)
             Path("qemu-efi-aarch64/QEMU_EFI.fd"),  # Debian and Ubuntu
-            None  # Terminator
         ],
         "x86_64": [
             Path("edk2/x64/OVMF_CODE.fd"),  # Arch Linux (current), Fedora
             Path("edk2-ovmf/x64/OVMF_CODE.fd"),  # Arch Linux (old)
             Path("OVMF/OVMF_CODE.fd"),  # Debian and Ubuntu
-            None  # Terminator
         ]
     }  # yapf: disable
 
@@ -396,12 +394,8 @@ def get_efi_args(guest_arch):
         )
         return []
 
-    for efi_img_location in efi_img_locations[guest_arch]:
-        if efi_img_location is None:
-            raise Exception(f"edk2 could not be found for {guest_arch}!")
-        efi_img = Path("/usr/share", efi_img_location)
-        if efi_img.exists():
-            break
+    usr_share = Path('/usr/share')
+    efi_img = utils.find_first_file(usr_share, efi_img_locations[guest_arch])
 
     if guest_arch == "arm64":
         # Sizing the images to 64M is recommended by "Prepare the firmware" section at
@@ -424,15 +418,8 @@ def get_efi_args(guest_arch):
         efi_vars_locations = [
             Path("edk2/x64/OVMF_VARS.fd"),  # Arch Linux and Fedora
             Path("OVMF/OVMF_VARS.fd"),  # Debian and Ubuntu
-            None  # Terminator
         ]
-        for efi_vars_location in efi_vars_locations:
-            if efi_vars_location is None:
-                raise Exception("OVMF_VARS.fd could not be found!")
-            efi_vars = Path('/usr/share', efi_vars_location)
-            if efi_vars.exists():
-                break
-
+        efi_vars = utils.find_first_file(usr_share, efi_vars_locations)
         efi_vars_qemu = base_folder.joinpath("images", guest_arch,
                                              efi_vars.name)
         shutil.copyfile(efi_vars, efi_vars_qemu)

--- a/utils.py
+++ b/utils.py
@@ -30,6 +30,29 @@ def die(string):
     sys.exit(1)
 
 
+def find_first_file(relative_root, possible_files):
+    """
+    Attempts to find the first option available in the list of files relative
+    to a specified root folder.
+
+    Parameters:
+        relative_root (Path): A Path object containing the folder to search for
+                              files within.
+        possible_files (list): A list of Paths that may be within the relative
+                               root folder. They will be automatically appended
+                               to relative_root.
+    Returns:
+        The full path to the first file found in the list. If none could be
+        found, an Exception is raised.
+    """
+    for possible_file in possible_files:
+        if (full_path := relative_root.joinpath(possible_file)).exists():
+            return full_path
+    raise Exception(
+        f"No files from list ('{', '.join(possible_files)}') could be found within '{relative_root}'!"
+    )
+
+
 def get_full_kernel_path(kernel_location, image, arch=None):
     """
     Get the full path to a kernel image based on the architecture and image

--- a/utils.py
+++ b/utils.py
@@ -30,7 +30,7 @@ def die(string):
     sys.exit(1)
 
 
-def find_first_file(relative_root, possible_files):
+def find_first_file(relative_root, possible_files, required=True):
     """
     Attempts to find the first option available in the list of files relative
     to a specified root folder.
@@ -41,6 +41,8 @@ def find_first_file(relative_root, possible_files):
         possible_files (list): A list of Paths that may be within the relative
                                root folder. They will be automatically appended
                                to relative_root.
+        required (bool): Whether or not the requested file is required for the
+                         script to work properly.
     Returns:
         The full path to the first file found in the list. If none could be
         found, an Exception is raised.
@@ -49,10 +51,13 @@ def find_first_file(relative_root, possible_files):
         if (full_path := relative_root.joinpath(possible_file)).exists():
             return full_path
 
-    files_str = "', '".join([str(elem) for elem in possible_files])
-    raise Exception(
-        f"No files from list ('{files_str}') could be found within '{relative_root}'!"
-    )
+    if required:
+        files_str = "', '".join([str(elem) for elem in possible_files])
+        raise Exception(
+            f"No files from list ('{files_str}') could be found within '{relative_root}'!"
+        )
+
+    return None
 
 
 def get_full_kernel_path(kernel_location, image, arch=None):

--- a/utils.py
+++ b/utils.py
@@ -48,8 +48,10 @@ def find_first_file(relative_root, possible_files):
     for possible_file in possible_files:
         if (full_path := relative_root.joinpath(possible_file)).exists():
             return full_path
+
+    files_str = "', '".join([str(elem) for elem in possible_files])
     raise Exception(
-        f"No files from list ('{', '.join(possible_files)}') could be found within '{relative_root}'!"
+        f"No files from list ('{files_str}') could be found within '{relative_root}'!"
     )
 
 


### PR DESCRIPTION
virtiofs, available in QEMU 5.2 or newer and Linux guests 5.4 or newer,
is a more modern way to pass local folders along to QEMU, as it takes
advantage of the fact that the folders are on the same machine as the
hypervisor.

To use virtiofs, we first need to run `virtiofsd`, which is included with
most base QEMU packages. Once we find it, we run it in the background
and connect to it using some QEMU parameters, which were shamelessly
taken from the official virtiofs website:

https://virtio-fs.gitlab.io/howto-qemu.html

To use it within the guest (you can use a different path than
`/mnt/shared` but `mount -t virtio shared` must be used):

```
  / # mkdir /mnt/shared
  / # mount -t virtiofs shared /mnt/shared
  / # echo "$(uname -a)" >/mnt/shared/foo
```

On the host:

```
  $ cat shared/foo
  Linux (none) 6.1.0-rc8-next-20221207 #2 SMP PREEMPT Wed Dec  7 14:56:03 MST 2022 aarch64 GNU/Linux
```

This does require guest kernel support (`CONFIG_VIRTIO_FS=y`), otherwise
it will not work inside the guest:

```
  / # mount -t virtiofs shared /mnt/shared
  mount: mounting shared on /mnt/shared failed: No such device
```

Closes: https://github.com/ClangBuiltLinux/boot-utils/issues/81
