### PR TITLE
boot-qemu.py: Check gdb_bin earlier

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -754,6 +754,8 @@ def launch_qemu(cfg):
     pretty_print_qemu_info(qemu_cmd[0])
 
     if gdb:
+        utils.check_cmd(gdb_bin)
+
         while True:
             utils.check_cmd("lsof")
             lsof = subprocess.run(["lsof", "-i:1234"],
@@ -766,7 +768,6 @@ def launch_qemu(cfg):
             utils.green("Starting QEMU with GDB connection on port 1234...")
             with subprocess.Popen(qemu_cmd + ["-s", "-S"]) as qemu_process:
                 utils.green("Starting GDB...")
-                utils.check_cmd(gdb_bin)
                 gdb_cmd = [gdb_bin]
                 gdb_cmd += [kernel_location.joinpath("vmlinux")]
                 gdb_cmd += ["-ex", "target remote :1234"]


### PR DESCRIPTION
Otherwise, the call to `sys.exit()` in `die()` does not work and we end up
hanging.

Additionally, move it out of the while loop, as it does not make send to
check for `gdb_bin` every single time we want to invoke it.
