### PR TITLE
ruff.toml: Disable S603 and S607

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -24,5 +24,7 @@ ignore = [
     'PLR0913', # too-many-arguments
     'PLR0915', # too-many-statements
     'PLR2004', # magic-value-comparison
+    'S603', # subprocess-without-shell-equals-true
+    'S607', # start-process-with-partial-path
 ]
 target-version = 'py38'


### PR DESCRIPTION
Reading the bandit documentation, these warnings are low severity and
it would make the code significantly worse to try and work around them,
so opt out of them. These calls are working as intended and this script
is designed to be used interactively so injection is not a concern.

Link: https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
Link: https://bandit.readthedocs.io/en/latest/plugins/b607_start_process_with_partial_path.html
