### PR TITLE
boot-qemu.py: Add ppc64 big endian ELFv2 file strings to file_rosetta

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -707,6 +707,8 @@ def guess_arch(kernel_arg):
         'ELF 32-bit LSB executable, MIPS, MIPS32': 'mipsel',
         'ELF 32-bit MSB executable, PowerPC': 'ambiguous',  # could be ppc32 or ppc32_mac
         'ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, Power ELF V1 ABI': 'ppc64',
+        'ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI': 'ppc64',
+        'ELF 64-bit MSB pie executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI': 'ppc64',
         'ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI': 'ppc64le',
         'ELF 64-bit LSB executable, UCB RISC-V': 'riscv',
         'ELF 64-bit MSB executable, IBM S/390': 's390',


### PR DESCRIPTION
This is needed to automatically boot `ppc64_guest_defconfig` +
`CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y`.

Add both the pie and non-pie variants, even though it is unlikely that
`CONFIG_RELOCATABLE` will be disabled, as it is selected by a few
different options in the defconfigs that this script will typically be
booting, but it does not hurt to be proactive.
