### PR TITLE
utils: Expand relative paths in get_full_kernel_path()

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -90,7 +90,7 @@ def get_full_kernel_path(kernel_location, image, arch=None):
     if not kernel.exists():
         die(f"Kernel ('{kernel}') does not exist!")
 
-    return kernel
+    return kernel.resolve()
 
 
 def green(string):


### PR DESCRIPTION
When attempting to use `-k .` with `boot-uml.py`, the following stacktrace
is observed:

```
  $ .../boot-uml.py -k .
  $ linux ubd0=.../boot-utils/images/x86_64/rootfs.ext4
  Traceback (most recent call last):
    File ".../boot-utils/boot-uml.py", line 82, in <module>
      run_kernel(kernel, decomp_rootfs(), args.interactive)
    File ".../boot-utils/boot-uml.py", line 75, in run_kernel
      subprocess.run(uml_cmd, check=True)
    File "/usr/lib/python3.11/subprocess.py", line 548, in run
      with Popen(*popenargs, **kwargs) as process:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
      self._execute_child(args, executable, preexec_fn, close_fds,
    File "/usr/lib/python3.11/subprocess.py", line 1917, in _execute_child
      raise child_exception_type(errno_num, err_msg, err_filename)
  FileNotFoundError: [Errno 2] No such file or directory: PosixPath('linux')
```

This is because `subprocess.run()` tries to locate the `linux` binary in
`PATH`, not the current directory.

Fix this by always returning an absolute path from
`get_full_kernel_path()`, so that `subprocess.run()` uses the correct
binary.

Closes: #103
