### PR TITLE
boot-qemu.py: Fix downloading LoongArch firmware

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -489,6 +489,7 @@ class LoongArchQEMURunner(QEMURunner):
         bios = Path(utils.BOOT_UTILS, 'images', self._initrd_arch,
                     'edk2-loongarch64-code.fd')
         if not bios.exists():
+            bios.parent.mkdir(exist_ok=True, parents=True)
             firmware_url = f"https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/{bios.name}"
             utils.green(
                 f"Downloading LoongArch firmware from {firmware_url}...")


### PR DESCRIPTION
Ensure `images/loongarch` exists before trying to download the firmware.
I missed this because `images/loongarch` was erroneously a part of the
history when LoongArch support was merged in #109.
