### PR TITLE
boot-qemu.py: Fix GDB check in QEMURunner

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -283,7 +283,7 @@ class QEMURunner:
             ]  # yapf: disable
 
         # Kernel options
-        if self.interactive or args.gdb:
+        if self.interactive or self.gdb:
             self.cmdline.append('rdinit=/bin/sh')
         if self.gdb:
             self.cmdline.append('nokaslr')


### PR DESCRIPTION
This has been broken for an embarrassingly long time...

Fixes: 09a59ca ("boot-qemu.py: Do not make gdb imply interactive")
