### PR TITLE
ruff.toml: Update for 0.2.0

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,7 @@
-# https://beta.ruff.rs/docs/rules/
+target-version = 'py38'
+
+# https://docs.astral.sh/ruff/rules/
+[lint]
 select = [
     'A', # flake8-builtins
     'ARG', # flake8-unused-arguments
@@ -27,4 +30,3 @@ ignore = [
     'S603', # subprocess-without-shell-equals-true
     'S607', # start-process-with-partial-path
 ]
-target-version = 'py38'


### PR DESCRIPTION
There is a deprecation warning for top level lint settings:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

Move these under the lint section. Additionally, update the link to the rules.
