### PR TITLE
boot-utils: Address new pylint possibly-used-before-assignment warnings

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -125,6 +125,9 @@ class QEMURunner:
         utils.check_cmd(decomp_prog)
         if decomp_prog in ('gzip', ):
             decomp_cmd = [decomp_prog, '-c', '-d', self.kernel]
+        else:
+            raise RuntimeError(
+                f"Unsupported decompression program ('{decomp_prog}')?")
         decomp = subprocess.run(decomp_cmd, capture_output=True, check=True)
 
         utils.check_cmd('strings')

--- a/utils.py
+++ b/utils.py
@@ -212,6 +212,9 @@ def prepare_initrd(architecture, rootfs_format='cpio', gh_json_file=None):
 
     # Download the ramdisk if it is not already downloaded
     if not src.exists():
+        # gh_json_rel cannot be unset when used here because the elif condition
+        # above is the same as this one, which causes the script to exit.
+        # pylint: disable-next=possibly-used-before-assignment
         download_initrd(gh_json_rel, src)
     # If it is already downloaded, check that it is up to date and download
     # an update only if necessary.


### PR DESCRIPTION
```
boot-qemu.py:148:32: E0606: Possibly using variable 'decomp_cmd' before assignment (possibly-used-before-assignment)
utils.py:215:24: E0606: Possibly using variable 'gh_json_rel' before assignment (possibly-used-before-assignment)
```
