### PR TITLE
boot-qemu.py: Fix always downloading LoongArch firmware

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -510,12 +510,8 @@ class LoongArchQEMURunner(QEMURunner):
         self._initrd_arch = 'loongarch'
 
         bios = Path(utils.BOOT_UTILS, 'images', self._initrd_arch,
-                    'edk2-loongarch64-code.fd')
+                    'QEMU_EFI.fd')
         if not bios.exists():
-            # Loongson renamed this in https://github.com/loongson/Firmware/commit/638906de6143283d86c70d80f4e9a30b50731c24
-            # so download it to the new location if it does not exist already.
-            bios = bios.with_name('QEMU_EFI.fd')
-
             bios.parent.mkdir(exist_ok=True, parents=True)
             firmware_url = f"https://github.com/loongson/Firmware/raw/main/LoongArchVirtMachine/{bios.name}"
             utils.green(


### PR DESCRIPTION
If the old firmware filename does not exist, the new firmware is always downloaded, even if it already exists. Remove the handling for the old to new transition so that the firmware is only downloaded when it is actually needed.
