### PR TITLE
boot-qemu.py: Add '-M' / '--modules'

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -52,6 +52,7 @@ class QEMURunner:
         self.kernel = None
         self.kernel_dir = None
         self.memory = '1G'
+        self.modules = None
         self.supports_efi = False
         # It may be tempting to use self.use_kvm during initialization of
         # subclasses to set certain properties but the user can explicitly opt
@@ -173,7 +174,8 @@ class QEMURunner:
         if not self._initrd_arch:
             raise RuntimeError('No initrd architecture specified?')
         return utils.prepare_initrd(self._initrd_arch,
-                                    gh_json_file=self.gh_json_file)
+                                    gh_json_file=self.gh_json_file,
+                                    modules=self.modules)
 
     def _run_fg(self):
         # Pretty print and run QEMU command
@@ -855,6 +857,12 @@ def parse_arguments():
         "Value for '-m' QEMU option (default: generally '512m', depends on machine)",
     )
     parser.add_argument(
+        '-M',
+        '--modules',
+        help=
+        'Path to .cpio generated with the Linux kernel\'s "modules-cpio-pkg" target'
+    )
+    parser.add_argument(
         '-s',
         '--smp',
         type=int,
@@ -936,6 +944,16 @@ if __name__ == '__main__':
 
     if args.memory:
         runner.memory = args.memory
+
+    if args.modules:
+        if not (modules := Path(args.modules).resolve()).exists():
+            raise FileNotFoundError(
+                f"Supplied modules .cpio ('{modules}') does not exist?")
+        if not args.memory:
+            utils.yellow(
+                'Memory not specified, the default may be too small for modules...'
+            )
+        runner.modules = modules
 
     if args.no_kvm:
         runner.use_kvm = False

--- a/utils.py
+++ b/utils.py
@@ -172,7 +172,10 @@ def green(string):
     print(f"\n\033[01;32m{string}\033[0m", flush=True)
 
 
-def prepare_initrd(architecture, rootfs_format='cpio', gh_json_file=None):
+def prepare_initrd(architecture,
+                   rootfs_format='cpio',
+                   gh_json_file=None,
+                   modules=None):
     """
     Returns a decompressed initial ramdisk.
 
@@ -227,6 +230,24 @@ def prepare_initrd(architecture, rootfs_format='cpio', gh_json_file=None):
     check_cmd('zstd')
     (dst := src.with_suffix('')).unlink(missing_ok=True)
     subprocess.run(['zstd', '-d', src, '-o', dst, '-q'], check=True)
+
+    if modules:
+        # "new" cpio magic bytes
+        cpio_sig = bytes([0x30, 0x37, 0x30, 0x37, 0x30, 0x31])
+        with modules.open('rb') as module_file:
+            if module_file.read(6) != cpio_sig:
+                raise RuntimeError(
+                    f"{modules} does not have cpio magic bytes, was it generated with the 'modules-cpio-pkg' target?"
+                )
+
+        (new_dst :=
+         dst.parent.joinpath('rootfs-modules.cpio')).unlink(missing_ok=True)
+        with subprocess.Popen(['cat', dst, modules],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT) as proc, new_dst.open(
+                                  'xb') as dst_file:
+            dst_file.write(proc.stdout.read())
+        dst = new_dst
 
     return dst
 


### PR DESCRIPTION
The Linux kernel recently gained a target to automatically package modules in a CPIO archive [1]. With this, we can easily concatenate our existing initrd with the modules archive to test loading modules with `boot-qemu.py`.

Link: https://git.kernel.org/linus/2a9c8c0b59d366acabb8f891e84569376f3e2709 [1]
