### PR TITLE
ruff.toml: Update for RUF201 in ruff 0.15.22

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -33,14 +33,14 @@ extend-select = [
     'W', # pycodestyle
 ]
 ignore = [
-    'E501', # line-too-long
-    'PLR0911', # too-many-return-statments
-    'PLR0912', # too-many-branches
-    'PLR0913', # too-many-arguments
-    'PLR0915', # too-many-statements
-    'PLR2004', # magic-value-comparison
-    'S404', # suspicious-subprocess-import
-    'S603', # subprocess-without-shell-equals-true
-    'S607', # start-process-with-partial-path
+    'line-too-long',
+    'magic-value-comparison',
+    'start-process-with-partial-path',
+    'subprocess-without-shell-equals-true',
+    'suspicious-subprocess-import',
+    'too-many-arguments',
+    'too-many-branches',
+    'too-many-return-statements',
+    'too-many-statements',
 ]
 preview = true


### PR DESCRIPTION
This rule migrates to the human-readable names for rules in ignore.
