### PR TITLE
boot-qemu.py: Add '-nographic' to ppc32_mac machine

### DIFF
--- a/boot-qemu.py
+++ b/boot-qemu.py
@@ -592,6 +592,7 @@ class PowerPC32MacQEMURunner(PowerPC32QEMURunner):
 
         self._default_kernel_path = Path('vmlinux')
         self._machine: str = 'mac99'
+        self._qemu_args.append('-nographic')
 
 
 class PowerPC64QEMURunner(QEMURunner):


### PR DESCRIPTION
This is needed to configure the NVRAM in QEMU to redirect the console to the serial port, which avoids a long hang on boot.

Link: https://lore.kernel.org/c6bf0bc3-353b-4d61-a6bc-d84e10f7d811@ilande.co.uk/
